### PR TITLE
fix: 实例化 Project 后添加 tsconfig 中的所有文件会导致编译第一个文件时把整个 src 都编译了，改为仅添加 d.t…

### DIFF
--- a/src/core/compiler.ts
+++ b/src/core/compiler.ts
@@ -143,8 +143,8 @@ export class Compiler implements ForRule {
                 'compilerOptions': this.compilerOptions,
                 'fileSystem': this.host
             });
-            // 先添加所有文件，否则编译单个文件没加载全局的 d.ts 会报错
-            this.project.addSourceFilesFromTsConfig(this.configPath);
+            // 先添加 baseDir 下的所有 d.ts，防止编译单文件时未加载全局变量/类型会报错
+            this.project.addSourceFilesAtPaths(this.baseDir + '/**/*.d.ts');
         }
         return this.project;
     }


### PR DESCRIPTION
…s 加载必要的全局类型声明